### PR TITLE
CHAM-59 FIX: 스트리밍 메세지 수신 중 Enter를 통한 추가 질문 전달 비활성화

### DIFF
--- a/src/components/chat/ChatbotInput.tsx
+++ b/src/components/chat/ChatbotInput.tsx
@@ -89,7 +89,7 @@ export default function ChatbotInput({
               ? '가족 요금제에 대해 궁금한 점을 물어보세요...'
               : '메시지를 입력하세요...'
           }
-          onKeyPress={(e) => e.key === 'Enter' && handleSend()}
+          onKeyPress={(e) => (e.key === 'Enter' && !isStreaming) && handleSend()}
           className={`flex-1 border-[#81C784] focus-visible:ring-[#81C784] ${isDarkMode ? 'bg-gray-700 text-white' : ''
             }`}
         />


### PR DESCRIPTION
## 유형
<!-- PR 유형을 선택해주세요 -->
- [ ] 기능 추가
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 기타

## 설명
<!-- 변경 사항에 대한 간략한 설명 -->
메세지를 보내고 챗봇의 응답을 기다릴 때 Enter 버튼을 통해 추가적인 질문 수신이 가능한 현상 FIX
## 테스트
<!-- 테스트 방법 간략하게 작성 -->
1. 아무 메세지나 보낸다.
2. 다음 질문을 입력한 후 Enter를 눌러서 전송을 시도한다.

